### PR TITLE
Fix junit setup - remove junit 4 dependency, update to recent junit 5…

### DIFF
--- a/adl/src/test/java/org/openehr/adlReader/AdlReaderTest.java
+++ b/adl/src/test/java/org/openehr/adlReader/AdlReaderTest.java
@@ -2,7 +2,8 @@ package org.openehr.adlReader;
 
 import org.antlr.v4.runtime.CharStreams;
 import org.antlr.v4.runtime.CommonTokenStream;
-import org.junit.Test;
+
+import org.junit.jupiter.api.Test;
 import org.openehr.adlparser.AdlLexer;
 import org.openehr.adlparser.AdlParser;
 

--- a/build.gradle
+++ b/build.gradle
@@ -23,10 +23,9 @@ subprojects {
         dependsOn generateGrammarSource
     }
     dependencies {
-        implementation 'junit:junit:4.12'
         antlr 'org.antlr:antlr4:4.9.2'
-        testImplementation 'org.junit.jupiter:junit-jupiter-api:5.6.0'
-        testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine'
+        testImplementation "org.junit.jupiter:junit-jupiter-api:5.7.2"
+        testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:5.7.2"
         api 'org.antlr:antlr4-runtime:4.9.2'
     }
 


### PR DESCRIPTION
… version

You were mixing junit 4 and junit 5. You used hte junit5 runner with a junit 4 test annotation. And you didn't add the vintage test runner. So junit did not find any tests.

This removes the junit 4 dependency, sets it to the latest junit 5 release and replaced it with the correct @Test annotation.